### PR TITLE
Update principal engineering resume

### DIFF
--- a/resume/typst-basic/main.typ
+++ b/resume/typst-basic/main.typ
@@ -9,8 +9,9 @@
   personal-site: "nahtnam.com",
   accent-color: "#000000",
   font: "New Computer Modern",
+  font-size: 10.5pt,
   paper: "us-letter",
-  margin: 0.4in,
+  margin: 0.5in,
   author-position: center,
   personal-info-position: center,
 )
@@ -18,42 +19,44 @@
 == Work Experience
 
 #work(
-  company: "Mercury",
-  title: "Principal Software Engineer",
+  title: "Mercury",
   location: "Remote",
-  dates: dates-helper(start-date: "Jan 2026", end-date: "Present"),
+  dates: dates-helper(start-date: "Nov 2021", end-date: "Present"),
 )
-- Lead *AI-DX* developer experience across engineering, product, and design.
-- Own the shift from a Haskell monolith to *TypeScript micro-services* for future products.
-- Lead two new products: a new vertical from scratch and an *AI-powered product* offering.
+#pad(left: 10pt)[
+  #work(
+    title: "Principal Software Engineer, Applied AI",
+    dates: dates-helper(start-date: "Jan 2026", end-date: "Present"),
+  )
+  - Designed and built the TypeScript agent harness for #link("https://mercury.com/blog/security-principles-command")[*Mercury Command*], an LLM-powered AI agent, replacing its Haskell predecessor; led 8 engineers from prototype to an *all-customer rollout in 10 weeks*.
+  - Built a dynamically loaded, team-owned skill system that enables *10+ product teams* to add capabilities without changing Command's core runtime.
+  - Designed financial-action guardrails where *the model proposes, product backends enforce, and users authorize*; execution occurs outside the model and remains traceable, with *zero unauthorized executions across 20,000+ completed actions*.
+  - Seven weeks after launch, *80,000+ users* had used Command across 65 workflows; 3,000+ user-approved payment and transfer submissions totaled *\$22M+*.
+  - Advanced from IC2 to Principal in four years, becoming one of *6 Principals among 300 engineers*.
 
-#work(
-  company: "Mercury",
-  title: "Staff Software Engineer",
-  location: "Remote",
-  dates: dates-helper(start-date: "May 2023", end-date: "Jan 2026"),
-)
-- Led a team to build a new marketing *Design System* with *Next.js*, unlocking millions in more efficient ad spend.
-- Made mercury.com maintainable by marketing, legal, and compliance teams.
-- Owned large shifts across the organization's frontend and backend stacks.
+  #v(2pt)
+  #work(
+    title: "Staff Software Engineer",
+    dates: dates-helper(start-date: "May 2023", end-date: "Jan 2026"),
+  )
+  - Owned Mercury's AI developer experience for *300 engineers*: rolled out Claude and Cursor, trained teams, and deployed AI review on every pull request.
+  - Secured CEO and CPO backing for a six-month #link("https://mercury.com")[mercury.com] rebuild; led 3 engineers to deliver a Next.js/CMS platform spanning 150+ pages and variants, serving millions of monthly page views, and cutting launch time from *two weeks to under a day*.
+  - Designed a typed MJML/TypeScript email service and compliance preview system; coordinated a six-month migration across 15+ teams and *500+ templates* supporting *millions of daily sends*, with no production incidents during migration.
 
-#work(
-  company: "Mercury",
-  title: "Engineering Manager",
-  location: "Remote",
-  dates: dates-helper(start-date: "Oct 2022", end-date: "May 2023"),
-)
-- Managed Growth engineering, a team of 8+, across multiple global timezones and performance management.
-- Led projects spanning acquisition, activation, virality, and retention.
-- Split a large team into more focused teams, then went heads-down to solve major acquisition issues.
+  #v(2pt)
+  #work(
+    title: "Engineering Manager",
+    dates: dates-helper(start-date: "Oct 2022", end-date: "May 2023"),
+  )
+  - Managed *8 engineers* across acquisition, activation, and retention; owned performance management and delivery, then reorganized Growth into two focused teams as Mercury scaled.
 
-#work(
-  company: "Mercury",
-  title: "Senior Software Engineer",
-  location: "Remote",
-  dates: dates-helper(start-date: "Nov 2021", end-date: "Oct 2022"),
-)
-- Built developer UX experiences that improved speed and efficiency for engineering and marketing teams.
+  #v(2pt)
+  #work(
+    title: "Software Engineer / Senior Software Engineer",
+    dates: dates-helper(start-date: "Nov 2021", end-date: "Oct 2022"),
+  )
+  - Promoted twice from IC2 to IC4 in 11 months.
+]
 
 #work(
   company: "Twingate",
@@ -61,7 +64,7 @@
   location: "Remote",
   dates: dates-helper(start-date: "Mar 2020", end-date: "Nov 2021"),
 )
-- As the primary frontend developer, worked with the VP of Design to rebuild the company's web application using *React*, *TypeScript*, *Next.js*, *Apollo*, and *Django*.
+- Served as Twingate's primary frontend engineer, owning onboarding, administration, and the zero-trust policy builder; set the React/TypeScript architecture and grew the frontend team from one to three engineers.
 
 #work(
   company: "Lime",
@@ -69,28 +72,25 @@
   location: "San Francisco, CA",
   dates: dates-helper(start-date: "Oct 2019", end-date: "Mar 2020"),
 )
-- Streamlined firmware releases by automating approvals from C-level executives to operations teams using *Approval Donkey*, *Zapier*, *Active Admin*, and *webhooks*.
-- Led SIM theft detection project reducing over \$500,000 in damages by assessing 250,000+ SIM cards and coordinating automated suspension with *Twilio*.
+- Partnered with Twilio's product team to build continuous risk monitoring for *250,000+ SIM cards*; the program was estimated to have avoided *\$500,000+ in theft losses*.
+- Built firmware rollout infrastructure that reconciled city-specific rules and configuration as scooters moved between markets, with approval workflows for safe releases.
 
 #work(
   company: "Lime, Rakuten/Ebates, Roambee, Card for Coin",
-  title: "Software Engineering Internships",
-  location: "",
+  title: "Engineering Internships",
   dates: dates-helper(start-date: "2015", end-date: "2019"),
 )
-- Shipped production features, automation, and pipelines with *React*, *TypeScript*, *Ruby on Rails*, *Python*, and *Scala*.
 
-== Showcase
+== Selected Writing & Research
 
-- *Mercury*: #link("https://mercury.com")[mercury.com] landing-page system for marketers; #link("https://mercury.com/command")[Command], an AI product for financial work.
-- *Projects*: Emit.so, Generate Metadata, Frunk, PG-Bossman.
-- *Stack*: AI SDK, MCP, RAG, agent loops, TypeScript, React, Next.js, Rails, Django, Postgres, Docker.
+- *Author*, #link("https://mercury.com/blog/security-principles-command")[#emph[Our security principles behind Command]] - Mercury, 2026.
+- *Co-author*, #link("https://doi.org/10.1145/3357223.3365442")[#emph[Vote Them Out: Detecting and Eliminating Byzantine Peers]] - poster accepted at ACM SoCC, 2019.
 
 == Education
 
 #generic-two-by-two(
   top-left: [*University of California, Santa Cruz*],
   top-right: [Sep 2017 #sym.dash.en Mar 2020],
-  bottom-left: [#emph[B.S., Computer Science], Magna Cum Laude, GPA: 3.9],
+  bottom-left: [#emph[B.S. in Computer Science], magna cum laude],
   bottom-right: [#emph[Santa Cruz, CA]],
 )

--- a/resume/typst-basic/template.typ
+++ b/resume/typst-basic/template.typ
@@ -80,7 +80,7 @@
     ],
   )
 
-  set par(justify: true)
+  set par(justify: false)
 
   body
 }
@@ -129,9 +129,13 @@
 }
 
 #let work(title: "", dates: "", company: "", location: "") = {
-  let title-company = if company == "" { title } else { title + " - " + company }
+  let heading = if company == "" {
+    strong(title)
+  } else {
+    [#strong(company) #sym.dash.en #title]
+  }
   generic-one-by-two(
-    left: strong(title-company),
+    left: heading,
     right: {
       if location == "" {
         dates


### PR DESCRIPTION
## Summary

- Reframe the Mercury experience around Command, applied AI, company-wide developer tooling, and durable platform work
- Preserve the engineering-management tour and earlier-company progression while tightening older experience
- Replace the generic showcase with selected writing and research
- Improve role/company hierarchy and switch body copy to ragged-right text for faster scanning

## Why

The previous resume materially understated Principal-level scope, personal authorship, cross-team leverage, and the safety architecture behind Command. This revision makes those signals legible while retaining a one-page format.

## Verification

- `bun run build:resume`
- Confirmed the generated PDF is one US-letter page with complete extractable text
- Visually inspected the rendered page for clipping, overlap, broken glyphs, hierarchy, and spacing
- `git diff --check`
- Repository pre-commit `ultracite` hook
