### PR TITLE
Align public profile and resume SEO

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -1,6 +1,6 @@
 # nahtnam
 
-Manthan (@nahtnam) is a Principal Software Engineer at Mercury. This personal site includes a portfolio, work history, writing, travel stats, a Golf R build ledger, and small public tools.
+Manthan Mallikarjun (@nahtnam) is a Principal Software Engineer at Mercury working on applied AI, product systems, and developer infrastructure. This personal site includes work history, writing, travel stats, a Golf R build ledger, and small public tools.
 
 ## Key pages
 
@@ -24,12 +24,12 @@ Manthan (@nahtnam) is a Principal Software Engineer at Mercury. This personal si
 
 ## Entity facts
 
-- Person: Manthan
+- Person: Manthan Mallikarjun
 - Handle: @nahtnam
 - Role: Principal Software Engineer at Mercury
-- Topics: software engineering, startups, developer tools, personal finance, travel, cars, productivity
+- Topics: applied AI, product engineering, developer infrastructure, TypeScript, startups, personal finance, travel, cars, productivity
 - GitHub: https://github.com/nahtnam
-- X: https://twitter.com/nahtnam
+- X: https://x.com/nahtnam
 
 ## Access notes
 

--- a/apps/web/src/lib/__tests__/resume-date.test.ts
+++ b/apps/web/src/lib/__tests__/resume-date.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  differenceInUtcMonths,
+  formatUtcMonthYear,
+  getUtcYear,
+} from "../resume-date";
+
+describe("resume date formatting", () => {
+  test("keeps UTC date-only timestamps in their stored month and year", () => {
+    const january = Date.UTC(2026, 0, 1);
+
+    expect(formatUtcMonthYear(january)).toBe("Jan 2026");
+    expect(getUtcYear(january)).toBe(2026);
+  });
+
+  test("calculates month differences using UTC date parts", () => {
+    expect(
+      differenceInUtcMonths({
+        end: new Date(Date.UTC(2022, 9, 1)),
+        start: new Date(Date.UTC(2021, 10, 1)),
+      })
+    ).toBe(11);
+  });
+});

--- a/apps/web/src/lib/__tests__/seo.test.ts
+++ b/apps/web/src/lib/__tests__/seo.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, test } from "vitest";
 
 import { generateOgImagePng } from "../og-image";
 import { getOgTitleFontSize } from "../og-image-renderer";
-import { createSeo, ogImageUrl, pageSeo } from "../seo";
+import { canonicalUrl, createSeo, ogImageUrl, pageSeo } from "../seo";
 
 describe("SEO metadata", () => {
   test("includes accessible social image metadata", () => {
     const seo = createSeo(pageSeo.home);
     const expectedAlt =
-      "Social preview reading “Manthan (@nahtnam)” for @nahtnam";
+      "Social preview reading “Manthan Mallikarjun (@nahtnam)” for @nahtnam";
 
     expect(seo.meta).toContainEqual({
       content: expectedAlt,
@@ -18,6 +18,24 @@ describe("SEO metadata", () => {
       content: expectedAlt,
       name: "twitter:image:alt",
     });
+  });
+
+  test("describes the public experience page without exposing a resume URL", () => {
+    const seo = createSeo(pageSeo.experience);
+
+    expect(seo.links).toContainEqual({
+      href: canonicalUrl("/experience"),
+      rel: "canonical",
+    });
+    expect(seo.meta).toContainEqual({
+      content: pageSeo.experience.description,
+      name: "description",
+    });
+    expect(seo.meta).toContainEqual({
+      content: "index, follow",
+      name: "robots",
+    });
+    expect(JSON.stringify(seo)).not.toContain("/resume");
   });
 
   test("versions minimal generated image URLs to invalidate preview caches", () => {

--- a/apps/web/src/lib/resume-date.ts
+++ b/apps/web/src/lib/resume-date.ts
@@ -1,0 +1,30 @@
+type DifferenceInUtcMonthsOptions = {
+  readonly end: Date;
+  readonly start: Date;
+};
+
+export function differenceInUtcMonths(options: DifferenceInUtcMonthsOptions) {
+  const { end, start } = options;
+  let months =
+    (end.getUTCFullYear() - start.getUTCFullYear()) * 12 +
+    end.getUTCMonth() -
+    start.getUTCMonth();
+
+  if (end.getUTCDate() < start.getUTCDate()) {
+    months -= 1;
+  }
+
+  return Math.max(0, months);
+}
+
+export function formatUtcMonthYear(timestamp: number) {
+  return new Date(timestamp).toLocaleDateString("en-US", {
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  });
+}
+
+export function getUtcYear(timestamp: number) {
+  return new Date(timestamp).getUTCFullYear();
+}

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -1,8 +1,8 @@
 import { appName, appUrl } from "@repo/config/app";
 
-export const siteTitle = "Manthan (@nahtnam)";
+export const siteTitle = "Manthan Mallikarjun (@nahtnam)";
 export const siteDescription =
-  "Personal site of Manthan (@nahtnam), Principal Software Engineer at Mercury, with writing about software, startups, personal finance, travel, and developer tools.";
+  "Manthan Mallikarjun is a Principal Software Engineer at Mercury working on applied AI, product systems, and developer infrastructure.";
 export const siteImage = `${appUrl}/assets/images/me.avif`;
 export const twitterHandle = "@nahtnam";
 const ogImageVersion = "4";
@@ -45,7 +45,7 @@ export const pageSeo = {
   },
   experience: {
     description:
-      "Professional experience, projects, and education for Manthan (@nahtnam), Principal Software Engineer at Mercury.",
+      "Engineering experience for Manthan (@nahtnam), spanning applied AI and fintech at Mercury, zero-trust security at Twingate, and connected mobility at Lime.",
     path: "/experience",
     socialTitle: "Experience",
     title: `Experience | ${siteTitle}`,
@@ -61,7 +61,7 @@ export const pageSeo = {
     description: siteDescription,
     path: "/",
     socialTitle: siteTitle,
-    title: `${siteTitle} - Principal Software Engineer at Mercury`,
+    title: `${siteTitle} | Principal Software Engineer at Mercury`,
   },
   pomodoro: {
     description:

--- a/apps/web/src/routes/-components/footer/index.tsx
+++ b/apps/web/src/routes/-components/footer/index.tsx
@@ -13,7 +13,7 @@ const pageLinks = [
 const socialLinks = [
   { label: "GitHub", url: "https://github.com/nahtnam" },
   { label: "LinkedIn", url: "https://linkedin.com/in/nahtnam" },
-  { label: "Twitter", url: "https://twitter.com/nahtnam" },
+  { label: "X", url: "https://x.com/nahtnam" },
 ];
 
 export function Footer() {
@@ -31,8 +31,8 @@ export function Footer() {
             />
           </p>
           <p className="mt-2 max-w-md text-sm leading-6 text-base-content/60">
-            Software engineer, indie hacker, and occasional writer building
-            things that matter.
+            Principal software engineer working on applied AI, product systems,
+            and developer infrastructure.
           </p>
           <p className="mt-3 font-mono text-[0.7rem] tracking-[0.12em] text-base-content/55 uppercase">
             &copy; {year} {appName}

--- a/apps/web/src/routes/_public/experience/index.tsx
+++ b/apps/web/src/routes/_public/experience/index.tsx
@@ -4,6 +4,11 @@ import { createFileRoute } from "@tanstack/react-router";
 import { createConvexRouteQueries } from "convex-route-query";
 import { ArrowUpRightIcon } from "lucide-react";
 
+import {
+  differenceInUtcMonths,
+  formatUtcMonthYear,
+  getUtcYear,
+} from "@/lib/resume-date";
 import { createSeo, pageSeo } from "@/lib/seo";
 
 const { listEducation, listExperiences, listProjects } =
@@ -127,11 +132,11 @@ function CompanyEntry(props: CompanyEntryProps) {
   const endDates = sortedRoles
     .map((role) => role.endDate)
     .filter((value): value is number => typeof value === "number");
-  const startYear = new Date(earliestStart).getFullYear();
+  const startYear = getUtcYear(earliestStart);
   let endLabel: number | string = isCurrent ? "Present" : "—";
 
   if (!(isCurrent || endDates.length === 0)) {
-    endLabel = new Date(Math.max(...endDates)).getFullYear();
+    endLabel = getUtcYear(Math.max(...endDates));
   }
 
   return (
@@ -191,8 +196,8 @@ function CompanyEntry(props: CompanyEntryProps) {
             </div>
             <div className="text-sm leading-6 text-base-content/70">
               <p className="font-mono">
-                {formatDate({ date: role.startDate })} –{" "}
-                {role.endDate ? formatDate({ date: role.endDate }) : "Present"}
+                {formatUtcMonthYear(role.startDate)} –{" "}
+                {role.endDate ? formatUtcMonthYear(role.endDate) : "Present"}
               </p>
               <p className="mt-1">{role.location}</p>
             </div>
@@ -335,7 +340,7 @@ function calculateTotalExperience(options: CalculateTotalExperienceOptions) {
 
   for (const experience of experiences) {
     const end = experience.endDate ? new Date(experience.endDate) : new Date();
-    totalMonths += differenceInMonths({
+    totalMonths += differenceInUtcMonths({
       end,
       start: new Date(experience.startDate),
     });
@@ -370,19 +375,6 @@ function groupByCompany(options: GroupByCompanyOptions) {
   return [...groups.values()];
 }
 
-type FormatDateOptions = {
-  readonly date: number;
-};
-
-function formatDate(options: FormatDateOptions) {
-  const { date } = options;
-
-  return new Date(date).toLocaleDateString("en-US", {
-    month: "short",
-    year: "numeric",
-  });
-}
-
 type FormatDurationOptions = {
   readonly endDate: number | undefined;
   readonly startDate: number;
@@ -391,31 +383,12 @@ type FormatDurationOptions = {
 function formatDuration(options: FormatDurationOptions) {
   const { endDate, startDate } = options;
   const totalMonths =
-    differenceInMonths({
+    differenceInUtcMonths({
       end: endDate ? new Date(endDate) : new Date(),
       start: new Date(startDate),
     }) + 1;
 
   return formatMonthCount({ totalMonths });
-}
-
-type DifferenceInMonthsOptions = {
-  readonly end: Date;
-  readonly start: Date;
-};
-
-function differenceInMonths(options: DifferenceInMonthsOptions) {
-  const { end, start } = options;
-  let months =
-    (end.getFullYear() - start.getFullYear()) * 12 +
-    end.getMonth() -
-    start.getMonth();
-
-  if (end.getDate() < start.getDate()) {
-    months -= 1;
-  }
-
-  return Math.max(0, months);
 }
 
 type FormatMonthCountOptions = {

--- a/apps/web/src/routes/_public/index.tsx
+++ b/apps/web/src/routes/_public/index.tsx
@@ -16,7 +16,7 @@ const { listExperiences, listPosts } = createConvexRouteQueries({
 const socialLinks = [
   { label: "GitHub", url: "https://github.com/nahtnam" },
   { label: "LinkedIn", url: "https://linkedin.com/in/nahtnam" },
-  { label: "Twitter", url: "https://twitter.com/nahtnam" },
+  { label: "X", url: "https://x.com/nahtnam" },
 ];
 export const Route = createFileRoute("/_public/")({
   component: HomePage,
@@ -46,15 +46,25 @@ function HomePage() {
   const personJsonLd = {
     "@context": "https://schema.org",
     "@type": "Person",
-    alternateName: "nahtnam",
+    alternateName: "@nahtnam",
+    alumniOf: {
+      "@type": "CollegeOrUniversity",
+      name: "University of California, Santa Cruz",
+    },
     description: siteDescription,
     image: siteImage,
     jobTitle: currentExperience?.title,
-    name: "Manthan",
+    knowsAbout: [
+      "Applied AI",
+      "Developer infrastructure",
+      "Product engineering",
+      "TypeScript",
+    ],
+    name: "Manthan Mallikarjun",
     sameAs: [
       "https://github.com/nahtnam",
       "https://linkedin.com/in/nahtnam",
-      "https://twitter.com/nahtnam",
+      "https://x.com/nahtnam",
     ],
     url: appUrl,
     worksFor: currentExperience
@@ -112,8 +122,7 @@ function HomePage() {
           ) : null}
 
           <p className="mt-6 text-pretty text-xl leading-8 text-base-content/75">
-            Software Engineer with experience at high-growth startups. Building
-            things that matter.
+            I work on applied AI, product systems, and developer infrastructure.
           </p>
 
           <p className="mt-5 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-base-content/60">

--- a/apps/web/src/routes/_public/resume/$variant.tsx
+++ b/apps/web/src/routes/_public/resume/$variant.tsx
@@ -34,6 +34,7 @@ export const Route = createFileRoute("/_public/resume/$variant")({
             "Cache-Control": "public, max-age=3600",
             "Content-Disposition": `inline; filename="manthan-mallikarjun-${variant}.pdf"`,
             "Content-Type": "application/pdf",
+            "X-Robots-Tag": "noindex, nofollow, noarchive",
           },
         });
       },

--- a/packages/config/src/app.ts
+++ b/packages/config/src/app.ts
@@ -3,8 +3,8 @@ export const isProduction = process.env.NODE_ENV === "production";
 
 export const appName = "nahtnam";
 export const siteDescription =
-  "Personal site of Manthan (@nahtnam), Principal Software Engineer at Mercury, with writing about software, startups, personal finance, travel, and developer tools.";
-export const siteTitle = "Manthan (@nahtnam)";
+  "Manthan Mallikarjun is a Principal Software Engineer at Mercury working on applied AI, product systems, and developer infrastructure.";
+export const siteTitle = "Manthan Mallikarjun (@nahtnam)";
 export const appUrl = isDevelopment
   ? "https://nahtnam.localhost"
   : "https://www.nahtnam.com";

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/resume/:path*",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow, noarchive"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- align site copy and structured data with the applied AI and developer infrastructure positioning
- sharpen Experience metadata while keeping the private resume unlinked
- prevent `/resume/*` routes and PDFs from being indexed

## Verification
- `bun run --cwd apps/web test src/lib/__tests__/seo.test.ts`
- `bun run --cwd apps/web typecheck`
- `bunx oxfmt --check ...`
- `jq empty vercel.json`
- `git diff --check`