### PR TITLE
Escape JSON-LD script content

### DIFF
--- a/apps/web/src/lib/__tests__/seo.test.ts
+++ b/apps/web/src/lib/__tests__/seo.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "vitest";
 
 import { generateOgImagePng } from "../og-image";
 import { getOgTitleFontSize } from "../og-image-renderer";
-import { canonicalUrl, createSeo, ogImageUrl, pageSeo } from "../seo";
+import {
+  canonicalUrl,
+  createSeo,
+  ogImageUrl,
+  pageSeo,
+  serializeJsonLd,
+} from "../seo";
 
 describe("SEO metadata", () => {
   test("includes accessible social image metadata", () => {
@@ -44,6 +50,15 @@ describe("SEO metadata", () => {
 
     expect(imageUrl.searchParams.get("v")).toBe("4");
     expect([...imageUrl.searchParams.keys()]).toStrictEqual(["title", "v"]);
+  });
+
+  test("keeps JSON-LD data from closing its script element", () => {
+    const payload = "</script><script>alert('xss')</script>";
+    const serialized = serializeJsonLd({ description: payload });
+
+    expect(serialized).toContain("\\u003c/script>");
+    expect(serialized).not.toContain("<");
+    expect(JSON.parse(serialized)).toStrictEqual({ description: payload });
   });
 
   test("gives every public page a large-card image with matching Twitter metadata", () => {

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -105,6 +105,10 @@ export function ogImageUrl(options: OgImageOptions) {
   return imageUrl.toString();
 }
 
+export function serializeJsonLd(value: unknown) {
+  return JSON.stringify(value).replaceAll("<", "\\u003c");
+}
+
 export function createSeo(options: SeoOptions) {
   const canonical = canonicalUrl(options.path);
   const socialTitle = options.socialTitle ?? options.title;

--- a/apps/web/src/routes/_public/blog/$slug/index.tsx
+++ b/apps/web/src/routes/_public/blog/$slug/index.tsx
@@ -15,6 +15,7 @@ import {
   canonicalUrl,
   createSeo,
   ogImageUrl,
+  serializeJsonLd,
   siteImage,
   siteTitle,
 } from "@/lib/seo";
@@ -103,7 +104,7 @@ function BlogPostPage() {
   return (
     <div className="page-shell page-shell-wide">
       <script
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(articleJsonLd) }}
         type="application/ld+json"
       />
 

--- a/apps/web/src/routes/_public/index.tsx
+++ b/apps/web/src/routes/_public/index.tsx
@@ -5,7 +5,13 @@ import { Link, createFileRoute } from "@tanstack/react-router";
 import { createConvexRouteQueries } from "convex-route-query";
 import { ArrowRightIcon, ArrowUpRightIcon } from "lucide-react";
 
-import { createSeo, pageSeo, siteDescription, siteImage } from "@/lib/seo";
+import {
+  createSeo,
+  pageSeo,
+  serializeJsonLd,
+  siteDescription,
+  siteImage,
+} from "@/lib/seo";
 import { AnimatedIdentity } from "@/routes/-components/animated-identity";
 
 const { listExperiences, listPosts } = createConvexRouteQueries({
@@ -78,7 +84,7 @@ function HomePage() {
   return (
     <div className="container page-shell-wide pt-10 pb-14 sm:pt-14 sm:pb-20 lg:pt-20 lg:pb-24">
       <script
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(personJsonLd) }}
         type="application/ld+json"
       />
 


### PR DESCRIPTION
## What changed

- add a shared JSON-LD serializer that escapes HTML-significant `<` characters
- route the homepage Person and blog BlogPosting structured data through it
- add regression coverage for script-element termination while preserving JSON round-tripping

## Why

Imported social content can become blog metadata. Raw `JSON.stringify` output preserves a literal closing-script sequence, so externally influenced metadata could terminate the JSON-LD element after an administrator imported and published it. Escaping `<` as the equivalent JSON Unicode escape keeps the data valid while preventing it from being parsed as HTML markup.

## Impact

Public structured data remains semantically unchanged, but JSON-LD values can no longer escape their script element. No visual UI, content, analytics, domain, environment, database, or deployment behavior changes.

## Validation

- `bun --cwd apps/web vitest run src/lib/__tests__/seo.test.ts` — 7 passed
- `bun run --cwd apps/web typecheck` — passed
- `bun x oxlint` on the four touched files — passed
- `bun x ultracite check` on the four touched files — passed
- repository pre-commit Ultracite hook — passed on 188 files
- exploit/control harness confirmed closing-script variants are escaped and JSON values round-trip
- independent scoped review found no actionable issues

## Release state

This PR is draft-only for morning review. It has not been merged or deployed.
