### PR TITLE
Pin Patchworks action to an immutable commit

### DIFF
--- a/.github/workflows/patchworks.yaml
+++ b/.github/workflows/patchworks.yaml
@@ -13,6 +13,6 @@ jobs:
   patchworks:
     runs-on: ubuntu-latest
     steps:
-      - uses: ludicroushq/patchworks@v0
+      - uses: ludicroushq/patchworks@e68b50045d9c0f5370cada65b962d7ee05b39f10 # v0.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Pin `ludicroushq/patchworks` from mutable `v0` to the full commit SHA `e68b50045d9c0f5370cada65b962d7ee05b39f10`.
- Keep `# v0.1.4` as a maintenance annotation for future reviewed upgrades.

## Why

The scheduled/manual workflow grants `contents: write` and `pull-requests: write` and passes `GITHUB_TOKEN` to the third-party action. A mutable tag can be moved to different code after review, so the action should be bound to the reviewed immutable commit.

At review time, the authoritative Patchworks repository resolves `v0`, `v0.1.4`, and `patchworks@0.1.4` to this same verified commit. The `action.yml` at that commit has no required inputs and supports the existing `GITHUB_TOKEN` environment fallback, preserving the current workflow behavior.

## Verification

- `actionlint .github/workflows/patchworks.yaml`
- `git diff --check origin/main...HEAD`
- `yq` assertion that the Patchworks ref is exactly 40 lowercase hexadecimal characters
- `gitleaks dir .github/workflows --no-banner --redact`
- Repository pre-commit Ultracite hook
- Fresh GitHub API comparison confirming the pinned SHA still equals the current `v0` target

No workflow dispatch or CI rerun was performed.
