### PR TITLE
Rate limit Couch BnB password attempts

### DIFF
--- a/apps/web/src/lib/bnb/__tests__/session.server.test.ts
+++ b/apps/web/src/lib/bnb/__tests__/session.server.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   clearBnbSessionCookie,
   createBnbSessionCookie,
-  getBnbSessionPassword,
+  getBnbSessionToken,
 } from "../session.server";
 
 vi.mock(import("@repo/config/env/server"), () => ({
@@ -17,26 +17,45 @@ vi.mock(import("@repo/config/env/server"), () => ({
 }));
 
 describe("Couch BnB session cookies", () => {
-  it("round-trips the password without storing it as plaintext", () => {
-    const password = "friends-only-secret";
-    const setCookie = createBnbSessionCookie({ password });
+  it("round-trips an opaque capability without exposing it", () => {
+    const sessionToken = "a".repeat(64);
+    const setCookie = createBnbSessionCookie({
+      expiresAt: Date.now() + 60_000,
+      sessionToken,
+    });
     const cookie = setCookie.split(";", 1)[0] ?? "";
     const request = new Request("https://example.com/api/bnb/bookings", {
       headers: { Cookie: cookie },
     });
 
-    expect(cookie).not.toContain(password);
-    expect(getBnbSessionPassword(request)).toBe(password);
+    expect(cookie).not.toContain(sessionToken);
+    expect(getBnbSessionToken(request)).toBe(sessionToken);
   });
 
   it("rejects a tampered session", () => {
-    const setCookie = createBnbSessionCookie({ password: "secret" });
+    const setCookie = createBnbSessionCookie({
+      expiresAt: Date.now() + 60_000,
+      sessionToken: "b".repeat(64),
+    });
     const cookie = setCookie.split(";", 1)[0] ?? "";
     const request = new Request("https://example.com/api/bnb/bookings", {
       headers: { Cookie: `${cookie}tampered` },
     });
 
-    expect(getBnbSessionPassword(request)).toBeUndefined();
+    expect(getBnbSessionToken(request)).toBeUndefined();
+  });
+
+  it("rejects an expired capability", () => {
+    const setCookie = createBnbSessionCookie({
+      expiresAt: Date.now() - 1000,
+      sessionToken: "c".repeat(64),
+    });
+    const cookie = setCookie.split(";", 1)[0] ?? "";
+    const request = new Request("https://example.com/api/bnb/bookings", {
+      headers: { Cookie: cookie },
+    });
+
+    expect(getBnbSessionToken(request)).toBeUndefined();
   });
 
   it("clears the scoped cookie", () => {

--- a/apps/web/src/lib/bnb/session.server.ts
+++ b/apps/web/src/lib/bnb/session.server.ts
@@ -8,14 +8,15 @@ import {
 import { serverEnv } from "@repo/config/env/server";
 
 const COOKIE_NAME = "nahtnam_bnb_session";
-const SESSION_SECONDS = 60 * 60 * 24 * 30;
 
-export function createBnbSessionCookie(options: { password: string }) {
-  const expiresAt = Date.now() + SESSION_SECONDS * 1000;
-  const value = encryptSession({ expiresAt, password: options.password });
+export function createBnbSessionCookie(options: {
+  expiresAt: number;
+  sessionToken: string;
+}) {
+  const value = encryptSession(options);
 
   return serializeCookie({
-    maxAge: SESSION_SECONDS,
+    maxAge: Math.max(0, Math.floor((options.expiresAt - Date.now()) / 1000)),
     value,
   });
 }
@@ -24,7 +25,7 @@ export function clearBnbSessionCookie() {
   return serializeCookie({ maxAge: 0, value: "" });
 }
 
-export function getBnbSessionPassword(request: Request) {
+export function getBnbSessionToken(request: Request) {
   const value = readCookie({ cookieHeader: request.headers.get("cookie") });
   if (!value) {
     return;
@@ -35,7 +36,7 @@ export function getBnbSessionPassword(request: Request) {
     return;
   }
 
-  return session.password;
+  return session.sessionToken;
 }
 
 export function isSameOriginRequest(request: Request) {
@@ -46,7 +47,7 @@ export function isSameOriginRequest(request: Request) {
 
 type BnbSession = {
   expiresAt: number;
-  password: string;
+  sessionToken: string;
 };
 
 function encryptionKey() {
@@ -101,8 +102,8 @@ function decryptSession(value: string) {
     if (
       typeof parsed.expiresAt !== "number" ||
       !Number.isFinite(parsed.expiresAt) ||
-      typeof parsed.password !== "string" ||
-      !parsed.password
+      typeof parsed.sessionToken !== "string" ||
+      !/^[\da-f]{64}$/u.test(parsed.sessionToken)
     ) {
       return;
     }

--- a/apps/web/src/lib/convex-error.ts
+++ b/apps/web/src/lib/convex-error.ts
@@ -1,0 +1,17 @@
+import { ConvexError } from "convex/values";
+
+type IsConvexErrorCodeOptions = {
+  code: string;
+  error: unknown;
+};
+
+export function isConvexErrorCode(options: IsConvexErrorCodeOptions) {
+  const { code, error } = options;
+  if (!(error instanceof ConvexError) || typeof error.data !== "object") {
+    return false;
+  }
+
+  return (
+    error.data !== null && "code" in error.data && error.data.code === code
+  );
+}

--- a/apps/web/src/routes/api/bnb/bookings.tsx
+++ b/apps/web/src/routes/api/bnb/bookings.tsx
@@ -6,9 +6,11 @@ import { ConvexHttpClient } from "convex/browser";
 import { z } from "zod";
 
 import {
-  getBnbSessionPassword,
+  clearBnbSessionCookie,
+  getBnbSessionToken,
   isSameOriginRequest,
 } from "@/lib/bnb/session.server";
+import { isConvexErrorCode } from "@/lib/convex-error";
 
 const bookingSchema = z
   .object({
@@ -26,21 +28,31 @@ export const Route = createFileRoute("/api/bnb/bookings")({
   server: {
     handlers: {
       async GET({ request }) {
-        const password = getBnbSessionPassword(request);
-        if (!password) {
+        const sessionToken = getBnbSessionToken(request);
+        if (!sessionToken) {
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
 
         try {
           const convex = new ConvexHttpClient(clientEnv.VITE_CONVEX_URL);
-          const bookings = await convex.query(api.bnb.queries.listBookings, {
-            password,
+          const bookings = await convex.action(api.bnb.queries.listBookings, {
+            sessionToken,
           });
 
           return Response.json(bookings, {
             headers: { "Cache-Control": "private, no-store" },
           });
-        } catch {
+        } catch (error) {
+          if (isConvexErrorCode({ code: "UNAUTHORIZED", error })) {
+            return Response.json(
+              { error: "Unauthorized" },
+              {
+                headers: { "Set-Cookie": clearBnbSessionCookie() },
+                status: 401,
+              }
+            );
+          }
+
           return Response.json(
             { error: "Couch BnB is not configured." },
             { status: 503 }
@@ -52,8 +64,8 @@ export const Route = createFileRoute("/api/bnb/bookings")({
           return Response.json({ error: "Forbidden" }, { status: 403 });
         }
 
-        const password = getBnbSessionPassword(request);
-        if (!password) {
+        const sessionToken = getBnbSessionToken(request);
+        if (!sessionToken) {
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
 
@@ -79,11 +91,21 @@ export const Route = createFileRoute("/api/bnb/bookings")({
           const result = await convex.action(api.bnb.actions.requestBooking, {
             ...parsed.data,
             notes,
-            password,
+            sessionToken,
           });
 
           return Response.json(result, { status: 201 });
-        } catch {
+        } catch (error) {
+          if (isConvexErrorCode({ code: "UNAUTHORIZED", error })) {
+            return Response.json(
+              { error: "Unauthorized" },
+              {
+                headers: { "Set-Cookie": clearBnbSessionCookie() },
+                status: 401,
+              }
+            );
+          }
+
           return Response.json(
             { error: "Something went wrong. Try again." },
             { status: 500 }

--- a/apps/web/src/routes/api/bnb/session.tsx
+++ b/apps/web/src/routes/api/bnb/session.tsx
@@ -10,10 +10,17 @@ import {
   createBnbSessionCookie,
   isSameOriginRequest,
 } from "@/lib/bnb/session.server";
+import { isConvexErrorCode } from "@/lib/convex-error";
 
 const sessionSchema = z.object({
   password: z.string().min(1).max(200),
 });
+
+type BnbSessionCapability = {
+  expiresAt: number;
+  sessionToken: string;
+  success: true;
+};
 
 export const Route = createFileRoute("/api/bnb/session")({
   server: {
@@ -51,19 +58,35 @@ export const Route = createFileRoute("/api/bnb/session")({
 
         const convex = new ConvexHttpClient(clientEnv.VITE_CONVEX_URL);
 
+        let session: BnbSessionCapability;
         try {
-          await convex.action(api.bnb.actions.verifyPassword, parsed.data);
-        } catch {
-          return Response.json({ error: "Wrong password." }, { status: 401 });
+          session = await convex.action(
+            api.bnb.actions.verifyPassword,
+            parsed.data
+          );
+        } catch (error) {
+          if (isConvexErrorCode({ code: "RATE_LIMITED", error })) {
+            return Response.json(
+              { error: "Too many attempts. Try again later." },
+              { status: 429 }
+            );
+          }
+
+          if (isConvexErrorCode({ code: "UNAUTHORIZED", error })) {
+            return Response.json({ error: "Wrong password." }, { status: 401 });
+          }
+
+          return Response.json(
+            { error: "Couch BnB is not configured." },
+            { status: 503 }
+          );
         }
 
         return Response.json(
           { success: true },
           {
             headers: {
-              "Set-Cookie": createBnbSessionCookie({
-                password: parsed.data.password,
-              }),
+              "Set-Cookie": createBnbSessionCookie(session),
             },
           }
         );

--- a/packages/backend/convex/__tests__/bnb-security.test.ts
+++ b/packages/backend/convex/__tests__/bnb-security.test.ts
@@ -1,0 +1,223 @@
+/// <reference types="vite/client" />
+/* oxlint-disable sonarjs/no-hardcoded-passwords -- These are isolated authentication test fixtures. */
+
+import { convexTest } from "convex-test";
+import { makeFunctionReference } from "convex/server";
+import { describe, expect, test, vi } from "vitest";
+
+import type { Doc } from "../_generated/dataModel";
+import { BNB_SESSION_TTL_MS } from "../bnb/auth";
+import schema from "../schema";
+
+const modules = import.meta.glob(["../**/*.*s", "!../__tests__/**/*.*s"]);
+
+// fluent-convex 0.13 ships extensionless ESM imports in dist. Loading its
+// TypeScript source lets Vite resolve those imports inside the test runtime.
+vi.mock(import("fluent-convex"), () => {
+  const packageSource = [
+    "../../node_modules/fluent-convex/src",
+    "index.ts",
+  ].join("/");
+  return import(packageSource);
+});
+
+vi.mock(import("../lib/telegram"), () => ({
+  escapeTelegramHtml: (value: string) => value,
+  sendTelegramMessage: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+}));
+
+process.env.BNB_PASSWORD = "bnb-secret";
+
+const verifyPassword = makeFunctionReference<
+  "action",
+  { password: string },
+  { expiresAt: number; sessionToken: string; success: true }
+>("bnb/actions:verifyPassword");
+const listBookings = makeFunctionReference<
+  "action",
+  { sessionToken: string },
+  { accepted: Doc<"bnbBookings">[]; pending: Doc<"bnbBookings">[] }
+>("bnb/queries:listBookings");
+const requestBooking = makeFunctionReference<
+  "action",
+  {
+    checkIn: string;
+    checkOut: string;
+    guests: string[];
+    notes?: string;
+    sessionToken: string;
+  },
+  { success: true }
+>("bnb/actions:requestBooking");
+
+async function actionErrorCode(action: Promise<unknown>) {
+  try {
+    await action;
+    return "resolved";
+  } catch (error) {
+    if (typeof error !== "object" || error === null || !("data" in error)) {
+      return "unknown";
+    }
+
+    const { data } = error;
+    if (typeof data !== "object" || data === null || !("code" in data)) {
+      return "unknown";
+    }
+
+    return typeof data.code === "string" ? data.code : "unknown";
+  }
+}
+
+describe("BnB capability security", () => {
+  test("allows five wrong guesses, then returns a durable rate-limit error", async () => {
+    const t = convexTest(schema, modules);
+
+    const outcomes = [
+      await actionErrorCode(t.action(verifyPassword, { password: "wrong-0" })),
+      await actionErrorCode(t.action(verifyPassword, { password: "wrong-1" })),
+      await actionErrorCode(t.action(verifyPassword, { password: "wrong-2" })),
+      await actionErrorCode(t.action(verifyPassword, { password: "wrong-3" })),
+      await actionErrorCode(t.action(verifyPassword, { password: "wrong-4" })),
+      await actionErrorCode(
+        t.action(verifyPassword, { password: "wrong-final" })
+      ),
+      await actionErrorCode(
+        t.action(verifyPassword, { password: "bnb-secret" })
+      ),
+    ];
+
+    expect(outcomes).toStrictEqual([
+      "UNAUTHORIZED",
+      "UNAUTHORIZED",
+      "UNAUTHORIZED",
+      "UNAUTHORIZED",
+      "UNAUTHORIZED",
+      "RATE_LIMITED",
+      "RATE_LIMITED",
+    ]);
+  });
+
+  test("serializes concurrent guesses against the same budget", async () => {
+    const t = convexTest(schema, modules);
+    const outcomes = await Promise.all(
+      Array.from({ length: 8 }, (_, attempt) =>
+        actionErrorCode(
+          t.action(verifyPassword, { password: `parallel-${attempt}` })
+        )
+      )
+    );
+
+    expect(outcomes.toSorted()).toStrictEqual([
+      "RATE_LIMITED",
+      "RATE_LIMITED",
+      "RATE_LIMITED",
+      "UNAUTHORIZED",
+      "UNAUTHORIZED",
+      "UNAUTHORIZED",
+      "UNAUTHORIZED",
+      "UNAUTHORIZED",
+    ]);
+  });
+
+  test("mints a 256-bit capability while storing only its hash", async () => {
+    const t = convexTest(schema, modules);
+    const session = await t.action(verifyPassword, { password: "bnb-secret" });
+    const storedSessions = await t.run((ctx) =>
+      ctx.db.query("bnbSessions").withIndex("by_tokenHash").take(10)
+    );
+
+    expect(session).toMatchObject({
+      expiresAt: expect.any(Number),
+      sessionToken: expect.stringMatching(/^[\da-f]{64}$/u),
+      success: true,
+    });
+    expect(session.expiresAt).toBeGreaterThan(Date.now());
+    expect(storedSessions).toHaveLength(1);
+    expect(storedSessions[0]?.tokenHash).toMatch(/^[\da-f]{64}$/u);
+    expect({
+      hasRawTokenField:
+        storedSessions[0] !== undefined && "sessionToken" in storedSessions[0],
+      storedRawToken: storedSessions[0]?.tokenHash === session.sessionToken,
+    }).toStrictEqual({
+      hasRawTokenField: false,
+      storedRawToken: false,
+    });
+  });
+
+  test("only the minted capability can list bookings", async () => {
+    const t = convexTest(schema, modules);
+    await t.run((ctx) =>
+      ctx.db.insert("bnbBookings", {
+        checkIn: "2026-08-01",
+        checkOut: "2026-08-03",
+        guests: ["Ada"],
+        status: "accepted",
+      })
+    );
+
+    const session = await t.action(verifyPassword, { password: "bnb-secret" });
+
+    await expect(
+      t.action(listBookings, { sessionToken: "0".repeat(64) })
+    ).rejects.toMatchObject({ data: { code: "UNAUTHORIZED" } });
+
+    await expect(
+      t.action(listBookings, { sessionToken: session.sessionToken })
+    ).resolves.toMatchObject({ accepted: [{ guests: ["Ada"] }] });
+  });
+
+  test("does not accept an expired capability", async () => {
+    const now = Date.now();
+    vi.useFakeTimers({ now });
+    try {
+      const t = convexTest(schema, modules);
+      const session = await t.action(verifyPassword, {
+        password: "bnb-secret",
+      });
+
+      vi.advanceTimersByTime(BNB_SESSION_TTL_MS + 1);
+      await expect(
+        t.action(listBookings, { sessionToken: session.sessionToken })
+      ).rejects.toMatchObject({ data: { code: "UNAUTHORIZED" } });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("requires a capability when requesting a booking", async () => {
+    const t = convexTest(schema, modules);
+
+    await expect(
+      t.action(requestBooking, {
+        checkIn: "2026-08-01",
+        checkOut: "2026-08-03",
+        guests: ["Ada"],
+        password: "bnb-secret",
+        sessionToken: "f".repeat(64),
+      } as never)
+    ).rejects.toThrow("Unexpected field `password`");
+
+    await expect(
+      t.action(requestBooking, {
+        checkIn: "2026-08-01",
+        checkOut: "2026-08-03",
+        guests: ["Ada"],
+        sessionToken: "f".repeat(64),
+      })
+    ).rejects.toMatchObject({ data: { code: "UNAUTHORIZED" } });
+
+    const session = await t.action(verifyPassword, { password: "bnb-secret" });
+    await expect(
+      t.action(requestBooking, {
+        checkIn: "2026-08-01",
+        checkOut: "2026-08-03",
+        guests: ["Ada"],
+        sessionToken: session.sessionToken,
+      })
+    ).resolves.toStrictEqual({ success: true });
+
+    await expect(
+      t.run((ctx) => ctx.db.query("bnbBookings").take(10))
+    ).resolves.toMatchObject([{ guests: ["Ada"], status: "pending" }]);
+  });
+});

--- a/packages/backend/convex/__tests__/migration.test.ts
+++ b/packages/backend/convex/__tests__/migration.test.ts
@@ -32,13 +32,18 @@ const getPost = makeFunctionReference<
   PublicPost | null
 >("blog/queries:getPost");
 const listBookings = makeFunctionReference<
-  "query",
-  { password: string },
+  "action",
+  { sessionToken: string },
   {
     accepted: Doc<"bnbBookings">[];
     pending: Doc<"bnbBookings">[];
   }
 >("bnb/queries:listBookings");
+const verifyPassword = makeFunctionReference<
+  "action",
+  { password: string },
+  { expiresAt: number; sessionToken: string; success: true }
+>("bnb/actions:verifyPassword");
 const isAuthorized = makeFunctionReference<
   "query",
   Record<string, never>,
@@ -157,7 +162,7 @@ describe("migrated public data contracts", () => {
     });
   });
 
-  test("requires the server-held BnB password before exposing bookings", async () => {
+  test("requires a BnB capability before exposing bookings", async () => {
     const t = convexTest(schema, modules);
 
     await t.run(async (ctx) => {
@@ -181,11 +186,14 @@ describe("migrated public data contracts", () => {
       });
     });
 
-    await expect(t.query(listBookings, { password: "wrong" })).rejects.toThrow(
-      "Wrong password"
-    );
+    await expect(
+      t.action(listBookings, { sessionToken: "a".repeat(64) })
+    ).rejects.toThrow("Unauthorized");
 
-    const bookings = await t.query(listBookings, { password: "bnb-secret" });
+    const session = await t.action(verifyPassword, { password: "bnb-secret" });
+    const bookings = await t.action(listBookings, {
+      sessionToken: session.sessionToken,
+    });
 
     expect(bookings.accepted.map(({ guests }) => guests[0])).toStrictEqual([
       "Ada",

--- a/packages/backend/convex/bnb/actions.ts
+++ b/packages/backend/convex/bnb/actions.ts
@@ -4,14 +4,24 @@ import { ConvexError, v } from "convex/values";
 
 import type { Id } from "../_generated/dataModel";
 import { convex } from "../fluent";
-import { requireBnbPassword } from "../lib/secrets";
 import { escapeTelegramHtml, sendTelegramMessage } from "../lib/telegram";
+import {
+  assertValidBnbSessionToken,
+  BNB_SESSION_TTL_MS,
+  createBnbSessionToken,
+  hashBnbSessionToken,
+} from "./auth";
 
-type CreateBookingArgs = {
+type BookingInput = {
   checkIn: string;
   checkOut: string;
   guests: string[];
   notes?: string;
+};
+
+type CreateBookingArgs = BookingInput & {
+  now: number;
+  sessionTokenHash: string;
 };
 
 const createBookingReference = makeFunctionReference(
@@ -23,7 +33,21 @@ const createBookingReference = makeFunctionReference(
   Id<"bnbBookings">
 >;
 
-function assertBookingInput(args: CreateBookingArgs) {
+type PasswordVerificationResult =
+  | { status: "rate_limited" }
+  | { status: "valid" }
+  | { status: "wrong" };
+
+const authorizeSessionReference = makeFunctionReference(
+  "bnb/auth:authorizeBnbSession"
+) as unknown as FunctionReference<
+  "mutation",
+  "internal",
+  { expiresAt: number; password: string; tokenHash: string },
+  PasswordVerificationResult
+>;
+
+function assertBookingInput(args: BookingInput) {
   const datePattern = /^\d{4}-\d{2}-\d{2}$/u;
 
   if (!(datePattern.test(args.checkIn) && datePattern.test(args.checkOut))) {
@@ -65,9 +89,31 @@ function assertBookingInput(args: CreateBookingArgs) {
 export const verifyPassword = convex
   .action()
   .input({ password: v.string() })
-  .handler((_ctx, args) => {
-    requireBnbPassword(args.password);
-    return Promise.resolve({ success: true as const });
+  .handler(async (ctx, args) => {
+    const sessionToken = createBnbSessionToken();
+    const expiresAt = Date.now() + BNB_SESSION_TTL_MS;
+    const tokenHash = await hashBnbSessionToken(sessionToken);
+    const verification = await ctx.runMutation(authorizeSessionReference, {
+      expiresAt,
+      password: args.password,
+      tokenHash,
+    });
+
+    if (verification.status === "rate_limited") {
+      throw new ConvexError({
+        code: "RATE_LIMITED",
+        message: "Too many password attempts",
+      });
+    }
+
+    if (verification.status === "wrong") {
+      throw new ConvexError({
+        code: "UNAUTHORIZED",
+        message: "Wrong password",
+      });
+    }
+
+    return { expiresAt, sessionToken, success: true as const };
   })
   .public();
 
@@ -78,10 +124,11 @@ export const requestBooking = convex
     checkOut: v.string(),
     guests: v.array(v.string()),
     notes: v.optional(v.string()),
-    password: v.string(),
+    sessionToken: v.string(),
   })
   .handler(async (ctx, args) => {
-    requireBnbPassword(args.password);
+    assertValidBnbSessionToken(args.sessionToken);
+    const sessionTokenHash = await hashBnbSessionToken(args.sessionToken);
 
     const booking = {
       checkIn: args.checkIn,
@@ -90,7 +137,11 @@ export const requestBooking = convex
       notes: args.notes?.trim() || undefined,
     };
     assertBookingInput(booking);
-    await ctx.runMutation(createBookingReference, booking);
+    await ctx.runMutation(createBookingReference, {
+      ...booking,
+      now: Date.now(),
+      sessionTokenHash,
+    });
 
     const notesMessage = booking.notes
       ? `\n<b>Notes:</b>\n${escapeTelegramHtml(booking.notes)}`

--- a/packages/backend/convex/bnb/auth.ts
+++ b/packages/backend/convex/bnb/auth.ts
@@ -1,0 +1,122 @@
+import { ConvexError, v } from "convex/values";
+
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { convex } from "../fluent";
+import { featureEnv } from "../lib/env";
+
+const BNB_AUTH_SCOPE = "global" as const;
+const PASSWORD_WINDOW_MS = 15 * 60 * 1000;
+const MAX_FAILED_PASSWORD_ATTEMPTS = 5;
+export const BNB_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+
+export const authorizeBnbSession = convex
+  .mutation()
+  .input({
+    expiresAt: v.number(),
+    password: v.string(),
+    tokenHash: v.string(),
+  })
+  .handler(async (ctx, args) => {
+    const now = Date.now();
+    const attempt = await ctx.db
+      .query("bnbAuthAttempts")
+      .withIndex("by_scope", (query) => query.eq("scope", BNB_AUTH_SCOPE))
+      .unique();
+
+    const windowExpired =
+      attempt !== null && now >= attempt.windowStartedAt + PASSWORD_WINDOW_MS;
+
+    if (
+      attempt !== null &&
+      !windowExpired &&
+      attempt.failedAttempts >= MAX_FAILED_PASSWORD_ATTEMPTS
+    ) {
+      return { status: "rate_limited" as const };
+    }
+
+    const passwordMatches =
+      typeof featureEnv.BNB_PASSWORD === "string" &&
+      featureEnv.BNB_PASSWORD.length > 0 &&
+      args.password === featureEnv.BNB_PASSWORD;
+
+    // A successful attempt must not consume or reset the failed-attempt budget.
+    if (passwordMatches) {
+      await ctx.db.insert("bnbSessions", {
+        expiresAt: args.expiresAt,
+        tokenHash: args.tokenHash,
+      });
+      return { status: "valid" as const };
+    }
+
+    if (attempt === null) {
+      await ctx.db.insert("bnbAuthAttempts", {
+        failedAttempts: 1,
+        scope: BNB_AUTH_SCOPE,
+        windowStartedAt: now,
+      });
+      return { status: "wrong" as const };
+    }
+
+    if (windowExpired) {
+      await ctx.db.patch("bnbAuthAttempts", attempt._id, {
+        failedAttempts: 1,
+        windowStartedAt: now,
+      });
+      return { status: "wrong" as const };
+    }
+
+    await ctx.db.patch("bnbAuthAttempts", attempt._id, {
+      failedAttempts: attempt.failedAttempts + 1,
+    });
+    return { status: "wrong" as const };
+  })
+  .internal();
+
+export function assertValidBnbSessionToken(sessionToken: string) {
+  if (!/^[\da-f]{64}$/u.test(sessionToken)) {
+    throw new ConvexError({
+      code: "UNAUTHORIZED",
+      message: "Unauthorized",
+    });
+  }
+}
+
+export async function hashBnbSessionToken(sessionToken: string) {
+  const bytes = new TextEncoder().encode(sessionToken);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return toHex(new Uint8Array(digest));
+}
+
+export function createBnbSessionToken() {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return toHex(bytes);
+}
+
+type HasActiveBnbSessionOptions = {
+  ctx: MutationCtx | QueryCtx;
+  now: number;
+  tokenHash: string;
+};
+
+export async function hasActiveBnbSession(options: HasActiveBnbSessionOptions) {
+  const { ctx, now, tokenHash } = options;
+  const session = await ctx.db
+    .query("bnbSessions")
+    .withIndex("by_tokenHash", (query) => query.eq("tokenHash", tokenHash))
+    .unique();
+  return session !== null && session.expiresAt > now;
+}
+
+export function unauthorizedBnbSession(): never {
+  throw new ConvexError({
+    code: "UNAUTHORIZED",
+    message: "Unauthorized",
+  });
+}
+
+function toHex(bytes: Uint8Array) {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    ""
+  );
+}

--- a/packages/backend/convex/bnb/mutations.ts
+++ b/packages/backend/convex/bnb/mutations.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 
 import { convex } from "../fluent";
+import { hasActiveBnbSession, unauthorizedBnbSession } from "./auth";
 
 export const createBooking = convex
   .mutation()
@@ -9,8 +10,26 @@ export const createBooking = convex
     checkOut: v.string(),
     guests: v.array(v.string()),
     notes: v.optional(v.string()),
+    now: v.number(),
+    sessionTokenHash: v.string(),
   })
-  .handler((ctx, args) =>
-    ctx.db.insert("bnbBookings", { ...args, status: "pending" })
-  )
+  .handler(async (ctx, args) => {
+    if (
+      !(await hasActiveBnbSession({
+        ctx,
+        now: args.now,
+        tokenHash: args.sessionTokenHash,
+      }))
+    ) {
+      unauthorizedBnbSession();
+    }
+
+    return ctx.db.insert("bnbBookings", {
+      checkIn: args.checkIn,
+      checkOut: args.checkOut,
+      guests: args.guests,
+      notes: args.notes,
+      status: "pending",
+    });
+  })
   .internal();

--- a/packages/backend/convex/bnb/queries.ts
+++ b/packages/backend/convex/bnb/queries.ts
@@ -1,13 +1,34 @@
+import type { FunctionReference } from "convex/server";
+import { makeFunctionReference } from "convex/server";
 import { v } from "convex/values";
 
+import type { Doc } from "../_generated/dataModel";
 import { convex } from "../fluent";
-import { requireBnbPassword } from "../lib/secrets";
+import {
+  assertValidBnbSessionToken,
+  hashBnbSessionToken,
+  hasActiveBnbSession,
+  unauthorizedBnbSession,
+} from "./auth";
 
-export const listBookings = convex
+type ListBookingsResult = {
+  accepted: Doc<"bnbBookings">[];
+  pending: Doc<"bnbBookings">[];
+};
+
+export const listBookingsInternal = convex
   .query()
-  .input({ password: v.string() })
+  .input({ now: v.number(), tokenHash: v.string() })
   .handler(async (ctx, args) => {
-    requireBnbPassword(args.password);
+    if (
+      !(await hasActiveBnbSession({
+        ctx,
+        now: args.now,
+        tokenHash: args.tokenHash,
+      }))
+    ) {
+      unauthorizedBnbSession();
+    }
 
     const [accepted, pending] = await Promise.all([
       ctx.db
@@ -21,5 +42,28 @@ export const listBookings = convex
     ]);
 
     return { accepted, pending };
+  })
+  .internal();
+
+const listBookingsReference = makeFunctionReference(
+  "bnb/queries:listBookingsInternal"
+) as unknown as FunctionReference<
+  "query",
+  "internal",
+  { now: number; tokenHash: string },
+  ListBookingsResult
+>;
+
+export const listBookings = convex
+  .action()
+  .input({ sessionToken: v.string() })
+  .handler(async (ctx, args) => {
+    assertValidBnbSessionToken(args.sessionToken);
+    const tokenHash = await hashBnbSessionToken(args.sessionToken);
+
+    return ctx.runQuery(listBookingsReference, {
+      now: Date.now(),
+      tokenHash,
+    });
   })
   .public();

--- a/packages/backend/convex/lib/secrets.ts
+++ b/packages/backend/convex/lib/secrets.ts
@@ -2,12 +2,6 @@ import { ConvexError } from "convex/values";
 
 import { featureEnv } from "./env";
 
-export function requireBnbPassword(password: string) {
-  if (!featureEnv.BNB_PASSWORD || password !== featureEnv.BNB_PASSWORD) {
-    throw new ConvexError({ code: "UNAUTHORIZED", message: "Wrong password" });
-  }
-}
-
 export function requirePrintSecret(secret: string) {
   if (!featureEnv.PRINT_SECRET || secret !== featureEnv.PRINT_SECRET) {
     throw new ConvexError({ code: "UNAUTHORIZED", message: "Unauthorized" });

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -45,6 +45,12 @@ export default defineSchema({
     .index("by_publishedAt", ["publishedAt"])
     .index("by_categoryId", ["categoryId"]),
 
+  bnbAuthAttempts: defineTable({
+    failedAttempts: v.number(),
+    scope: v.literal("global"),
+    windowStartedAt: v.number(),
+  }).index("by_scope", ["scope"]),
+
   bnbBookings: defineTable({
     checkIn: v.string(),
     checkOut: v.string(),
@@ -56,6 +62,11 @@ export default defineSchema({
       v.literal("rejected")
     ),
   }).index("by_status", ["status"]),
+
+  bnbSessions: defineTable({
+    expiresAt: v.number(),
+    tokenHash: v.string(),
+  }).index("by_tokenHash", ["tokenHash"]),
 
   golfRItems: defineTable({
     attachments: v.optional(


### PR DESCRIPTION
## What changed

- enforce a durable global budget of five failed Couch BnB password attempts per 15-minute window
- check the lockout before comparing the shared password and persist failed attempts atomically
- mint a 256-bit, 24-hour BnB capability after successful verification and store only its SHA-256 hash
- require the capability for booking reads and requests, removing the two alternate raw-password oracles
- keep the capability in the existing encrypted, HttpOnly web session cookie and return HTTP 429 for lockouts

## Why

`bnb/actions:verifyPassword`, `bnb/actions:requestBooking`, and `bnb/queries:listBookings` were public Convex functions that accepted the shared password directly. An attacker could call those functions without using the TanStack session route and make unlimited online guesses.

The global budget is intentionally enforced inside Convex because the public action has no trustworthy caller identity. This can temporarily block new logins after abuse, while existing capability-backed sessions continue to work.

## Verification

- `bun run --cwd packages/backend test convex/__tests__/bnb-security.test.ts` — 6 passed
- `bun run --cwd packages/backend test convex/__tests__/migration.test.ts` — 9 passed
- `bun run --cwd apps/web test src/lib/bnb/__tests__/session.server.test.ts` — 4 passed
- `bun run --cwd packages/backend typecheck` — passed
- `bun run --cwd apps/web typecheck` — passed
- `bun x ultracite check <13 changed files>` — passed
- repository pre-commit Ultracite hook — passed

No Convex deployment, environment change, or remote data mutation was performed.
